### PR TITLE
Saved 3 chars on juggling async

### DIFF
--- a/09-juggling-async/index.js
+++ b/09-juggling-async/index.js
@@ -1,4 +1,4 @@
-c=[],j=0,m='map';process.argv.slice(2)[m]((u,i)=>{
+j=0,m='map';process.argv.slice(2)[m]((u,i,c)=>{
 c[i]='';require('http').get(u,r=>
   r.on('data',r=>c[i]+=r).on('end',_=>j++&&j==3&&c[m](r=>console.log(r)))
 )})


### PR DESCRIPTION
Removed the creation of the `c=[]` array and just use the array passed in the `map` method and override as you go.