### PR TITLE
Bugfix

### DIFF
--- a/05-filtered_ls/README.md
+++ b/05-filtered_ls/README.md
@@ -12,5 +12,5 @@ The list of files should be printed to the console, one file per line. You **mus
 index.js
 ```js
 a=process.argv;require('fs')
-  .readdir(a[2],(_,f)=>f.map(f=>~f.indexOf('.'+a[3])&&console.log(f)))
+  .readdir(a[2],(_,f)=>f.map(f=>f.endsWith('.'+a[3])&&console.log(f)))
 ```

--- a/05-filtered_ls/index.js
+++ b/05-filtered_ls/index.js
@@ -1,2 +1,2 @@
 a=process.argv;require('fs')
-  .readdir(a[2],(_,f)=>f.map(f=>~f.indexOf('.'+a[3])&&console.log(f)))
+  .readdir(a[2],(_,f)=>f.map(f=>f.endsWith('.'+a[3])&&console.log(f)))

--- a/06-make_it_modular/README.md
+++ b/06-make_it_modular/README.md
@@ -29,5 +29,5 @@ a=process.argv;require('./m')(a[2],a[3],(_,l)=>l.map(f=>console.log(f)))
 m.js
 ```js
 module.exports=(a,b,c)=>
-  require('fs').readdir(a,(_,f)=>_?c(_):c(null,f.filter(f=>~f.indexOf('.'+b))))
+  require('fs').readdir(a,(e,f)=>c(e,e?null:f.filter(f=>f.endsWith('.'+b))))
 ```

--- a/06-make_it_modular/m.js
+++ b/06-make_it_modular/m.js
@@ -1,2 +1,2 @@
 module.exports=(a,b,c)=>
-  require('fs').readdir(a,(_,f)=>_?c(_):c(null,f.filter(f=>~f.indexOf('.'+b))))
+  require('fs').readdir(a,(e,f)=>c(e,e?null:f.filter(f=>f.endsWith('.'+b))))


### PR DESCRIPTION
Unfortunately, this adds chars. 

`node index.js [dir] js` would previously include `.json` files too. 

*Edit:* @darcyclarke pointed out endswith which is the same length as the original and still ensures `json` files are excluded!